### PR TITLE
Terraform hotfix

### DIFF
--- a/04/src/.tflint.hcl
+++ b/04/src/.tflint.hcl
@@ -1,0 +1,22 @@
+config {
+  format           = "compact"
+  plugin_dir       = "/tflint/.tflint.d/plugins"
+  call_module_type = "local"
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+rule "terraform_module_pinned_source" {
+  enabled          = false
+  style            = "flexible"
+  default_branches = ["main"]
+}
+
+rule "terraform_required_providers" {
+  enabled = false
+  source  = false
+  version = false
+}

--- a/04/src/main.tf
+++ b/04/src/main.tf
@@ -1,16 +1,3 @@
-rule "terraform_module_pinned_source" {
-  enabled = false
-  style = "flexible"
-  default_branches = ["main"]
-}
-
-rule "terraform_required_providers" {
-  enabled = false
-  # defaults
-  source = false
-  version = false
-}
-
 data "template_file" "cloudinit" {
   template = file("./cloud-init.yml")
   vars = {

--- a/04/src/main.tf
+++ b/04/src/main.tf
@@ -1,5 +1,5 @@
 rule "terraform_module_pinned_source" {
-  enabled = true
+  enabled = false
   style = "flexible"
   default_branches = ["main"]
 }

--- a/04/src/main.tf
+++ b/04/src/main.tf
@@ -27,7 +27,7 @@ resource "yandex_vpc_subnet" "develop_b" {
 
 
 module "analytics_vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=1.0.0"
   env_name       = "develop" 
   network_id     = module.vpc_dev.vpc_subnet_dev.network_id
   subnet_zones   = [module.vpc_dev.vpc_subnet_dev.zone]
@@ -47,7 +47,7 @@ module "analytics_vm" {
 }
 
 module "marketing_vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=1.0.0"
   env_name       = "stage"
   network_id     = module.vpc_dev.vpc_subnet_dev.network_id
   subnet_zones   = [module.vpc_dev.vpc_subnet_dev.zone]

--- a/04/src/main.tf
+++ b/04/src/main.tf
@@ -4,6 +4,13 @@ rule "terraform_module_pinned_source" {
   default_branches = ["main"]
 }
 
+rule "terraform_required_providers" {
+  enabled = false
+  # defaults
+  source = false
+  version = false
+}
+
 data "template_file" "cloudinit" {
   template = file("./cloud-init.yml")
   vars = {

--- a/04/src/main.tf
+++ b/04/src/main.tf
@@ -1,3 +1,9 @@
+rule "terraform_module_pinned_source" {
+  enabled = true
+  style = "flexible"
+  default_branches = ["main"]
+}
+
 data "template_file" "cloudinit" {
   template = file("./cloud-init.yml")
   vars = {

--- a/04/src/providers.tf
+++ b/04/src/providers.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
-      required_version = "~>1.8.4"
     }
   }
   required_version = "~>1.8.4"

--- a/04/src/providers.tf
+++ b/04/src/providers.tf
@@ -6,6 +6,7 @@ terraform {
     template = {
       source  = "hashicorp/template"
       version = "~> 2"
+    }
   }
   required_version = "~>1.8.4"
  

--- a/04/src/providers.tf
+++ b/04/src/providers.tf
@@ -3,8 +3,9 @@ terraform {
     yandex = {
       source = "yandex-cloud/yandex"
     }
+    required_version = "~>1.8.4"
   }
-  required_version = "~>1.8.4"
+
 
   backend "s3" {
     endpoints = { s3 = "https://storage.yandexcloud.net" }

--- a/04/src/providers.tf
+++ b/04/src/providers.tf
@@ -3,6 +3,9 @@ terraform {
     yandex = {
       source = "yandex-cloud/yandex"
     }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2"
   }
   required_version = "~>1.8.4"
  

--- a/04/src/providers.tf
+++ b/04/src/providers.tf
@@ -3,10 +3,6 @@ terraform {
     yandex = {
       source = "yandex-cloud/yandex"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2"
-    }
   }
   required_version = "~>1.8.4"
  

--- a/04/src/providers.tf
+++ b/04/src/providers.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      required_version = "~>1.8.4"
     }
-    required_version = "~>1.8.4"
   }
-
-
+  required_version = "~>1.8.4"
+ 
   backend "s3" {
     endpoints = { s3 = "https://storage.yandexcloud.net" }
     bucket    = "tfstate-develop-1"

--- a/04/src/variables.tf
+++ b/04/src/variables.tf
@@ -19,39 +19,3 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
-
-variable "vpc_name" {
-  type        = string
-  default     = "develop"
-  description = "VPC network&subnet name"
-}
-
-###common vars
-
-variable "vms_ssh_root_key" {
-  type        = string
-  default     = "your_ssh_ed25519_key"
-  description = "ssh-keygen -t ed25519"
-}
-
-###example vm_web var
-variable "vm_web_name" {
-  type        = string
-  default     = "netology-develop-platform-web"
-  description = "example vm_web_ prefix"
-}
-
-###example vm_db var
-variable "vm_db_name" {
-  type        = string
-  default     = "netology-develop-platform-db"
-  description = "example vm_db_ prefix"
-}
-
-
-


### PR DESCRIPTION
TFlint:
root@nt src]# docker run --rm -v $(pwd):/tflint -t ghcr.io/terraform-linters/tflint --config=/tflint/.tflint.hcl --chdir=/tflint
[root@nt src]#


Chekov:
terraform scan results:
Passed checks: 2, Failed checks: 0, Skipped checks: 0
Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
        PASSED for resource: analytics_vm
        File: /main.tf:29-47
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-tag
Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
        PASSED for resource: marketing_vm
        File: /main.tf:49-68
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-tag


[root@nt src]# terraform plan
data.template_file.cloudinit: Reading...
module.marketing_vm.data.yandex_compute_image.my_image: Reading...
module.analytics_vm.data.yandex_compute_image.my_image: Reading...
data.template_file.cloudinit: Read complete after 0s [id=c570666f4efd1577763e8af5d8fd7d948de7a69724a57e5ea3cc3a7fe7458e3c]
module.analytics_vm.data.yandex_compute_image.my_image: Read complete after 0s [id=fd892vjp5gajiqr0g1b3]
module.marketing_vm.data.yandex_compute_image.my_image: Read complete after 1s [id=fd892vjp5gajiqr0g1b3]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # yandex_vpc_network.develop will be created
  + resource "yandex_vpc_network" "develop" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "develop"
      + subnet_ids                = (known after apply)
    }

  # yandex_vpc_subnet.develop_a will be created
  + resource "yandex_vpc_subnet" "develop_a" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop-ru-central1-a"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

  # yandex_vpc_subnet.develop_b will be created
  + resource "yandex_vpc_subnet" "develop_b" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop-ru-central1-b"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.2.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-b"
    }

  # module.analytics_vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = "develop-vm-0"
      + id                        = (known after apply)
      + labels                    = {
          + "project" = "acanalytics"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJbFQwlXpyF5D6x8yiptgTG/Are3CfQ94MRINvltKRs2
                package_update: true
                package_upgrade: false
                packages:
                  - vim
                  - nginx
            EOT
        }
      + name                      = "develop-vm-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd892vjp5gajiqr0g1b3"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.analytics_vm.yandex_compute_instance.vm[1] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = "develop-vm-1"
      + id                        = (known after apply)
      + labels                    = {
          + "project" = "acanalytics"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJbFQwlXpyF5D6x8yiptgTG/Are3CfQ94MRINvltKRs2
                package_update: true
                package_upgrade: false
                packages:
                  - vim
                  - nginx
            EOT
        }
      + name                      = "develop-vm-1"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd892vjp5gajiqr0g1b3"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.marketing_vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = "stage-web-stage-0"
      + id                        = (known after apply)
      + labels                    = {
          + "project" = "marketing"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJbFQwlXpyF5D6x8yiptgTG/Are3CfQ94MRINvltKRs2
                package_update: true
                package_upgrade: false
                packages:
                  - vim
                  - nginx
            EOT
        }
      + name                      = "stage-web-stage-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd892vjp5gajiqr0g1b3"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.vpc_dev.yandex_vpc_network.vpc_dev will be created
  + resource "yandex_vpc_network" "vpc_dev" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "dev"
      + subnet_ids                = (known after apply)
    }

  # module.vpc_dev.yandex_vpc_subnet.vpc_subnet_dev will be created
  + resource "yandex_vpc_subnet" "vpc_subnet_dev" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

Plan: 8 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + vpc_subnet_dev = {
      + created_at     = (known after apply)
      + description    = null
      + dhcp_options   = []
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop"
      + network_id     = (known after apply)
      + route_table_id = null
      + timeouts       = null
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }
